### PR TITLE
Conversation auto start for iOS

### DIFF
--- a/ios/RCTSmooch/RCTSmooch.m
+++ b/ios/RCTSmooch/RCTSmooch.m
@@ -15,8 +15,8 @@
 {
   [Smooch getConversations: ^(NSError *_Nullable error, NSArray *_Nullable conversations) {
     if (conversations == nil || [conversations count] == 0) {
-      [Smooch createConversationWithName: nil 
-            description:nil iconUrl:nil avatarUrl:nil metadata:nil message:nil completionHandler: nil];
+      [Smooch createConversationWithName: "displayName1" 
+            description: "description1" iconUrl:nil avatarUrl:nil metadata:nil message:"olá" completionHandler: nil];
     }
   }];
 }

--- a/ios/RCTSmooch/RCTSmooch.m
+++ b/ios/RCTSmooch/RCTSmooch.m
@@ -10,6 +10,8 @@
 @interface SmoochManager()
 @end
 
+NSString *TriggerMessageText = @"PROACTIVE_TRIGGER";
+
 @implementation MyConversationDelegate
 - (void)conversation:(SKTConversation *)conversation willShowViewController:(UIViewController *)viewController
 {

--- a/ios/RCTSmooch/RCTSmooch.m
+++ b/ios/RCTSmooch/RCTSmooch.m
@@ -14,11 +14,20 @@
 - (void)conversation:(SKTConversation *)conversation willShowViewController:(UIViewController *)viewController
 {
   [Smooch getConversations: ^(NSError *_Nullable error, NSArray *_Nullable conversations) {
+    NSDictionary *msgMetadata = @{@"isHidden": @YES};
+    NSArray<SKTMessage *> *proactiveTriggerMessage = @[[[SKTMessage alloc] initWithText:TriggerMessageText payload:@"" metadata:msgMetadata]];
     if (conversations == nil || [conversations count] == 0) {
-      [Smooch createConversationWithName: "displayName1" 
-            description: "description1" iconUrl:nil avatarUrl:nil metadata:nil message:"olá" completionHandler: nil];
+    [Smooch createConversationWithName: nil
+                            description: nil iconUrl:nil avatarUrl:nil metadata: nil message:proactiveTriggerMessage completionHandler: nil];
     }
   }];
+}
+
+- (nullable SKTMessage *)conversation:(SKTConversation *)conversation willDisplayMessage:(SKTMessage *)message{
+    if(message != nil && [message.text isEqualToString:TriggerMessageText]){
+        return nil;
+    }
+    return message;
 }
 
 - (void)setControllerState {


### PR DESCRIPTION
### Context 

Our chatbot should start the conversation as soon as the user opens the chat, which means that it must be proactive. This feature is missing on iOS side.

### What was done

* Adding a proactive message: a message with a default text is beign sent to the bot when the chat is opened.
* Adding a message filter: before displaying the messages, a filter is applied on the `willDisplayMessage` to check if the message to be displayed is the proactive message. If so, it will ignore the message, otherwise it shows the correct message. 

Through network inspection I have find out that `createConversationWithName` is sending only the text and the type on the final request, ignoring important parameters such as `payload` and `metadata` of the `SKTMessage`. Because of that, we are not able to send the `isHidden` attribute as a metadata.

As a workaround, I have implemented a filter that check if the message to be displayed is our default message used to initiate the conversation.

I have also kept the correct implementation in case they fix their SDK.