### PR TITLE
Improve handling for bot startup on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ yarn install
 
 ## IOS
 
- * This uses Smooch IOS SDK v10.1.3
+ * This uses Smooch IOS SDK v11.0.0
 
  * You must also have your React dependencies defined in your Podfile as described [here](http://facebook.github.io/react-native/releases/0.31/docs/troubleshooting.html#missing-libraries-for-react), for example:
 

--- a/react-native-zendesk-sunshine.podspec
+++ b/react-native-zendesk-sunshine.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/pier-digital/react-native-zendesk-sunshine" }
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "10.0"
-  s.dependency 'Smooch', '~> 10.1.3'
+  s.dependency 'Smooch', '~> 11.0.0'
   s.dependency 'React'
 end


### PR DESCRIPTION
### Context

Com a ativação da feature de multiconversas, é necessário adaptar o tratamento para criação da mensagem inicial que força a inicialização do bot.

Para isso foi necessária a atualização da SDK para a versão 11.0.0