### PR TITLE
Fix SmoochCallback generics type

### DIFF
--- a/android/src/main/java/com/smooch/rnsmooch/ReactNativeSmooch.java
+++ b/android/src/main/java/com/smooch/rnsmooch/ReactNativeSmooch.java
@@ -211,7 +211,7 @@ public class ReactNativeSmooch extends ReactContextBaseJavaModule {
 
     private void createConversation(String conversationName, final Message message, final Promise promise) {
         List<Message> messages = Arrays.asList(message);
-        Smooch.createConversation(conversationName, "", null, null, messages, message.getMetadata(), new SmoochCallback<Void>() {
+        Smooch.createConversation(conversationName, "", null, null, messages, message.getMetadata(), new SmoochCallback<String>() {
             @Override
             public void run(Response<Void> response) {
                 if (response.getError() != null) {


### PR DESCRIPTION
- Change from Void to String since Smooch.createConversations sends a string to the callback

[Latest Android SDK release](https://github.com/zendesk/sunshine-conversations-android/releases/tag/9.1.2)
[Bitrise build with the error](https://app.bitrise.io/build/3b90a8a2-9bfd-42be-99ba-bb4f9660641e)