### PR TITLE
Fix gradle dependencies and update to mavenCentral server

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "https://maven.google.com"
         }
@@ -9,7 +9,7 @@ allprojects {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
### Context
Atualiza `build.gradle` que estava quebrando build mobile no bitrise

### What was made
- Remove `jcenter()` de processo de build
- Adiciona `mavenCentral`
- Volta versão do `android.tools.build.gradle` de `2.3.3` para `2.3.0` (última versão 2.X disponível no mavenCentral)